### PR TITLE
ASDK-175955-Updated SDK Guide links

### DIFF
--- a/docs/App-Tunneling/Airwatch-SDK.md
+++ b/docs/App-Tunneling/Airwatch-SDK.md
@@ -30,7 +30,7 @@ In order to redirect your application’s traffic to an AirWatch supported proxy
 - AWWebViewClient
 - AWURLConnection
 
-No additional logic is needed to handle the tunneling of a network request from your internal application. For more information refer [Networking Developer Guide](https://developer.omnissa.com/ws1-uem-sdk-for-android/guides/WS1AndroidDeveloperGuideNetworking.pdf)
+No additional logic is needed to handle the tunneling of a network request from your internal application. For more information refer [Networking Developer Guide](https://developer.omnissa.com/ws1-sdk-for-android/guides/WS1AndroidDeveloperGuideNetworking.pdf)
 
 ## Tutorial
 

--- a/docs/SDK-Setup.md
+++ b/docs/SDK-Setup.md
@@ -16,7 +16,7 @@ Before moving forward to the SDK setup tutorial, ensure you have completed the i
 
     Starting June 2024 version 24.06 onwards, Workspace ONE SDK for Android will **NOT** be distributed through the My Workspace ONE portal. 
     
-The SDK is accessible from a Maven repository. For integration documentation, please follow the instructions in the [Public Maven Repository Integration Note](https://developer.omnissa.com/ws1-uem-sdk-for-android/guides/WorkspaceONE_Android_PublicMavenNote.pdf), and KB article [General Availability of Workspace ONE SDK Android (6000158)](https://kb.omnissa.com/s/article/6000158) to integrate the Workspace ONE SDK Android package into their applications.
+The SDK is accessible from a Maven repository. For integration documentation, please follow the instructions in the [Public Maven Repository Integration Note](https://developer.omnissa.com/ws1-sdk-for-android/guides/WorkspaceONE_Android_PublicMavenNote.pdf), and KB article [General Availability of Workspace ONE SDK Android (6000158)](https://kb.omnissa.com/s/article/6000158) to integrate the Workspace ONE SDK Android package into their applications.
 
 ## Requirements
 
@@ -43,7 +43,7 @@ Refer to [index](index.md) Integration guides section for instructions on how to
 ### Configure the App theme to have the Branding Icon
 
 Set the SDK Branding Icon to be the image. This can be the app icon or an image specific to the app. The Branding Icon is required for SDK Login Flow integrations.
-Please follow the instructions in the [Workspace ONE for Android Branding Integration Guide](https://developer.omnissa.com/ws1-uem-sdk-for-android/guides/WorkspaceONE_Android_Branding.pdf)
+Please follow the instructions in the [Workspace ONE for Android Branding Integration Guide](https://developer.omnissa.com/ws1-sdk-for-android/guides/WorkspaceONE_Android_Branding.pdf)
 to set the SDK branding icon.
 
 ## Debug Your Application

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ hide:
 
 ## Overview
 
-If you haven’t already, please review the [Features Available](../../dev-centre/ws1/core-capabilities) and [Comparison of Technical Approaches](../../dev-centre/ws1/core-capabilities#technical-capabilities) sections to help determine the best technical approach (AppConfig.org, AirWatch SDK, App Wrapping) for your use case.
+If you haven’t already, please review the [Features Available](../../dev-centre/ws1/core-capabilities) section to help determine the best technical approach (AppConfig.org, AirWatch SDK, App Wrapping) for your use case.
 
 After you’ve been acquainted with the different options of integration with AirWatch, decide on a technical approach which best meets your use cases.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ For additional information, please visit the [Omnissa Legal Center](https://www.
 
     Starting June 2024 version 24.06 onwards, Workspace ONE SDK for Android will **NOT** be distributed through the My Workspace ONE portal. 
     
-The SDK is accessible from a Maven repository. For integration documentation, please follow the instructions in the [Public Maven Repository Integration Note](https://developer.omnissa.com/ws1-uem-sdk-for-android/guides/WorkspaceONE_Android_PublicMavenNote.pdf), and KB article [General Availability of Workspace ONE SDK Android (6000158)](https://kb.omnissa.com/s/article/6000158) to integrate the Workspace ONE SDK Android package into their applications.
+The SDK is accessible from a Maven repository. For integration documentation, please follow the instructions in the [Public Maven Repository Integration Note](https://developer.omnissa.com/ws1-sdk-for-android/guides/WorkspaceONE_Android_PublicMavenNote.pdf), and KB article [General Availability of Workspace ONE SDK Android (6000158)](https://kb.omnissa.com/s/article/6000158) to integrate the Workspace ONE SDK Android package into their applications.
 
 Refer to these guides for instructions on how to integrate your Android app with Workspace ONE.
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,7 +18,7 @@ Workspace ONE SDK for Android Release Notes describe the new features and enhanc
 
     Starting June 2024 version 24.06 onwards, Workspace ONE SDK for Android will **NOT** be distributed through the My Workspace ONE portal. 
     
-The SDK is accessible from a Maven repository. For integration documentation, please follow the instructions in the [Public Maven Repository Integration Note](https://developer.omnissa.com/ws1-uem-sdk-for-android/guides/WorkspaceONE_Android_PublicMavenNote.pdf), and KB article [General Availability of Workspace ONE SDK Android (6000158)](https://kb.omnissa.com/s/article/6000158) to integrate the Workspace ONE SDK Android package into their applications.
+The SDK is accessible from a Maven repository. For integration documentation, please follow the instructions in the [Public Maven Repository Integration Note](https://developer.omnissa.com/ws1-sdk-for-android/guides/WorkspaceONE_Android_PublicMavenNote.pdf), and KB article [General Availability of Workspace ONE SDK Android (6000158)](https://kb.omnissa.com/s/article/6000158) to integrate the Workspace ONE SDK Android package into their applications.
 
 Also when adding module dependencies, ensure the group and module names are in lowercase. Example: 
 ```c

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 # Project Information
 site_name: WS1 SDK for Android
-site_url: https://euc-dev.github.io/ws1-uem-sdk-for-android/
+site_url: https://euc-dev.github.io/ws1-sdk-for-android/
 site_author: Phil Helmling
 site_description: Submodule for developer.omnissa.com
 docs_dir: docs


### PR DESCRIPTION
Since we Updated the name of Workspace one SDK to
[WS1 SDK for Android](https://developer.omnissa.com/ws1-sdk-for-android/) instead of
[WS1 UEM SDK for Android](https://developer.omnissa.com/ws1-uem-sdk-for-android/).

All links pointing to this page had to be updated. This Pr includes all of those changes and updated to remove an unwanted section.